### PR TITLE
Add tsconfig.node.json file

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "ES2020", // Specify ECMAScript target version
+        "module": "commonjs", // Specify module code generation
+        "strict": true, // Enable all strict type-checking options
+        "esModuleInterop": true, // Enables emit interoperability between CommonJS and ES Modules
+        "skipLibCheck": true, // Skip type checking of declaration files
+        "forceConsistentCasingInFileNames": true // Disallow inconsistently-cased references to the same file
+    },
+    "include": ["src/**/*.ts"], // Include all TypeScript files in the src directory
+    "exclude": ["node_modules"] // Exclude the node_modules directory
+}


### PR DESCRIPTION
This pull request adds a new file, `tsconfig.node.json`, which includes the compiler options for TypeScript. The file specifies the ECMAScript target version, module code generation, strict type-checking options, interoperability between CommonJS and ES Modules, skipping type checking of declaration files, and disallowing inconsistently-cased references to the same file. The file also includes the configuration to include all TypeScript files in the `src` directory and exclude the `node_modules` directory.